### PR TITLE
Fix init

### DIFF
--- a/src/components/CoursesPage.js
+++ b/src/components/CoursesPage.js
@@ -5,12 +5,12 @@ import { Link } from "react-router-dom";
 import { loadCourses } from "../actions/courseActions";
 
 function CoursesPage() {
-  const [courses, setCourses] = useState([]);
+  const [courses, setCourses] = useState(courseStore.getCourses());
 
   useEffect(() => {
     courseStore.addChangeListener(onChange);
     console.log(courseStore);
-    if (courseStore.getCourses.length === 0) loadCourses();
+    if (courseStore.getCourses().length === 0) loadCourses();
     return () => courseStore.removeChangeListener(onChange); // cleanup on unmount
   }, []);
 


### PR DESCRIPTION
With these changes you'll see that you can nav between pages. Now your code matches what I show in the vid.

That said, you pointed out that the exercise files in the final module folder had a typo on [this line](https://github.com/Archy92/react-flux/blob/master/src/components/CoursesPage.js#L13).

That line should read:

```js
if (courseStore.getCourses().length === 0) loadCourses();
```

Note the parens on `getCourses()`. I've submitted a patch for that on the course final demo file. 

Thanks!